### PR TITLE
Support using asyncio async generators in trio.

### DIFF
--- a/trio_asyncio/base.py
+++ b/trio_asyncio/base.py
@@ -213,10 +213,8 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         coro = asyncio.ensure_future(coro, loop=self)
         return await run_future(coro)
 
-    def wrap_generator(self, gen):
-        # if inspect.isasyncgen(f):
-        # return self.wrap_generator(f)
-        return run_generator(self, gen())
+    def wrap_generator(self, gen, *args):
+        return run_generator(self, gen(*args))
 
     async def run_asyncio(self, proc, *args):
         """Run an asyncio function or method from Trio.

--- a/trio_asyncio/base.py
+++ b/trio_asyncio/base.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import inspect
 import math
 import trio
 import heapq
@@ -11,7 +12,7 @@ from .handles import Handle, TimerHandle
 
 from selectors import _BaseSelectorImpl, EVENT_READ, EVENT_WRITE
 
-from .util import run_future
+from .util import run_future, run_generator
 
 try:
     from trio.hazmat import wait_for_child
@@ -211,6 +212,11 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         self._check_closed()
         coro = asyncio.ensure_future(coro, loop=self)
         return await run_future(coro)
+
+    def wrap_generator(self, gen):
+        # if inspect.isasyncgen(f):
+        # return self.wrap_generator(f)
+        return run_generator(self, gen())
 
     async def run_asyncio(self, proc, *args):
         """Run an asyncio function or method from Trio.

--- a/trio_asyncio/loop.py
+++ b/trio_asyncio/loop.py
@@ -25,6 +25,7 @@ __all__ = [
     'run_future',
     'run_coroutine',
     'run_asyncio',
+    'wrap_generator',
     'TrioChildWatcher',
     'TrioPolicy',
 ]
@@ -167,6 +168,13 @@ class TrioChildWatcher:  # (asyncio.AbstractChildWatcher):
 
     def __exit__(self, *tb):
         self.close()
+
+
+def wrap_generator(proc, *args):
+    loop = asyncio.get_event_loop()
+    if not isinstance(loop, TrioEventLoop):
+        raise RuntimeError("Need to run in a trio_asyncio.open_loop() context")
+    return loop.wrap_generator(proc, *args)
 
 
 async def run_asyncio(proc, *args):


### PR DESCRIPTION
This is obviously not yet done, as missing the cancellation handling.
Looking for some preliminary feedback.

It works for the following code:

```
import asyncio
import trio
import trio_asyncio


@trio_asyncio.trio2aio
async def asyncio_generator():
    yield 1
    await asyncio.sleep(1)
    yield 2

async def async_main(*args):
    async with trio_asyncio.open_loop() as loop:
        async for m in asyncio_generator():
            print(m)
            
trio.run(async_main)
```