### PR TITLE
Async generators, continued

### DIFF
--- a/trio_asyncio/util.py
+++ b/trio_asyncio/util.py
@@ -76,7 +76,7 @@ async def run_generator(loop, async_generator):
             asyncio.ensure_future(consume_next(), loop=loop)
 
             item = await trio.hazmat.wait_task_rescheduled(abort_cb)
-            if item == STOP:
+            if item is STOP:
                 break
             yield item
 


### PR DESCRIPTION
Using `==` can cause errors, for example using grpc items, which raise an exception if compared with arbitrary objects.

I notice you already merged the other pull request. Do you still want me to add a test case? Note also the lack of support proper cancellation currently.