### PR TITLE
Use async_generator module for 3.5 support.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "trio",
+        "async_generator >= 1.6",
     ],
     # This means, just install *everything* you see under trio/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:

--- a/trio_asyncio/adapter.py
+++ b/trio_asyncio/adapter.py
@@ -1,7 +1,7 @@
 # This code implements a clone of the asyncio mainloop which hooks into
 # Trio.
 
-import inspect
+from async_generator import isasyncgenfunction
 import trio_asyncio
 
 # import logging
@@ -13,7 +13,7 @@ __all__ = ['trio2aio', 'aio2trio']
 
 
 def trio2aio(proc):
-    if inspect.isasyncgenfunction(proc):
+    if isasyncgenfunction(proc):
         @wraps(proc)
         def call(*args):
             return trio_asyncio.wrap_generator(proc, *args)

--- a/trio_asyncio/util.py
+++ b/trio_asyncio/util.py
@@ -4,6 +4,8 @@
 import trio
 import asyncio
 import sys
+from async_generator import async_generator, yield_
+
 
 __all__ = ['run_future']
 
@@ -49,6 +51,8 @@ async def run_future(future):
 
 STOP = object()
 
+
+@async_generator
 async def run_generator(loop, async_generator):
     task = trio.hazmat.current_task()
     raise_cancel = None
@@ -78,7 +82,7 @@ async def run_generator(loop, async_generator):
             item = await trio.hazmat.wait_task_rescheduled(abort_cb)
             if item is STOP:
                 break
-            yield item
+            await yield_(item)
 
     except asyncio.CancelledError as exc:
         if raise_cancel is not None:


### PR DESCRIPTION
The new async generator support as-is means that trio-asyncio no longer imports on 3.5 at all, when before it did. While the docs say it's not officially supported, it worked just fine. In particular, I am using it with PyPy, which seems to support some kind of weird mixture between 3.5 and 3.6, but mostly 3.5 and no async generator syntax.

Every trio user already has the `async_generator` module installed anyway, since it is a hard dependency of trio itself. I think it is therefore an easy decision to use it to bring back PyPy support.