### PR TITLE
Upgrade from deprecated trio.Queue; fix tests; fix docs

### DIFF
--- a/docs/source/rationale.rst
+++ b/docs/source/rationale.rst
@@ -41,10 +41,10 @@ domains rigidly separate.
 
 The core of the "normal" asyncio main loop is the repeated execution of
 synchronous code that's submitted to
-:meth:`asyncio.AbstractEventLoop.call_soon` or
-:meth:`asyncio.AbstractEventLoop.call_later`, or as the callbacks for
-:meth:`asyncio.AbstractEventLoop.add_reader` /
-:meth:`asyncio.AbstractEventLoop.add_writer`.
+:meth:`python:asyncio.loop.call_soon` or
+:meth:`python:asyncio.loop.call_later`, or as the callbacks for
+:meth:`python:asyncio.loop.add_reader` /
+:meth:`python:asyncio.loop.add_writer`.
 
 Everything else within the ``asyncio`` core, esp. Futures, Coroutines, and
 ``await``'ing them, is just syntactic sugar. There is no concept of a

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -522,13 +522,13 @@ Cancellations are also propagated whenever possible. This means
  Deferred Calls
 ----------------
 
-:meth:`asyncio.AbstractEventLoop.call_soon` and friends work as usual.
+:meth:`python:asyncio.loop.call_soon` and friends work as usual.
 
 ----------------
  Worker Threads
 ----------------
 
-:meth:`asyncio.AbstractEventLoop.run_in_executor` works as usual.
+:meth:`python:asyncio.loop.run_in_executor` works as usual.
 
 There is one caveat: the executor must be either ``None`` or an instance of
 :class:`trio_asyncio.TrioExecutor`. The constructor of this class accepts one
@@ -540,8 +540,8 @@ argument: the number of workers.
  File descriptors
 ------------------
 
-:meth:`asyncio.AbstractEventLoop.add_reader` and
-:meth:`asyncio.AbstractEventLoop.add_writer` work as usual, if you really
+:meth:`python:asyncio.loop.add_reader` and
+:meth:`python:asyncio.loop.add_writer` work as usual, if you really
 need them. Behind the scenes, these calls create a Trio task which runs the
 callback.
 
@@ -551,7 +551,7 @@ You might consider converting code using these calls to native Trio tasks.
  Signals
 ---------
 
-:meth:`asyncio.AbstractEventLoop.add_signal_handler` works as usual.
+:meth:`python:asyncio.loop.add_signal_handler` works as usual.
 
 ------------
 Subprocesses

--- a/newsfragments/49.bugfix.rst
+++ b/newsfragments/49.bugfix.rst
@@ -1,0 +1,1 @@
+Replace deprecated ``trio.Queue`` with new channels, requiring Trio 0.9 or later.

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ Matthias Urlichs <matthias@urlichs.de>
 """
 
 install_requires = [
-    "trio >= 0.5.0",
+    "trio >= 0.9.0",
     "async_generator >= 1.6",
     "outcome",
 ]

--- a/tests/interop/test_adapter.py
+++ b/tests/interop/test_adapter.py
@@ -6,8 +6,18 @@ import trio
 import sniffio
 from tests import aiotest
 import sys
+import warnings
 from async_generator import asynccontextmanager
 from .. import utils as test_utils
+
+
+def de_deprecate_converter(func):
+    def wrapper(proc):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', DeprecationWarning)
+            return func(proc)
+
+    return wrapper
 
 
 class SomeThing:
@@ -31,7 +41,7 @@ class SomeThing:
         self.flag |= 2
         return 8
 
-    @aio2trio
+    @de_deprecate_converter(aio2trio)
     async def dly_trio_depr(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "trio"
@@ -39,7 +49,7 @@ class SomeThing:
         self.flag |= 2
         return 8
 
-    @trio2aio
+    @de_deprecate_converter(trio2aio)
     async def dly_asyncio_depr(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"

--- a/tests/python/test_selector_events.py
+++ b/tests/python/test_selector_events.py
@@ -30,7 +30,7 @@ from asyncio.selector_events import _SelectorDatagramTransport
 MOCK_ANY = mock.ANY
 
 
-class TestBaseSelectorEventLoop(BaseSelectorEventLoop):
+class BaseSelectorEventLoopForTest(BaseSelectorEventLoop):
     def _make_self_pipe(self):
         self._ssock = mock.Mock()
         self._csock = mock.Mock()
@@ -58,7 +58,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         super().setUp()
         self.selector = mock.Mock()
         self.selector.select.return_value = []
-        self.loop = TestBaseSelectorEventLoop(self.selector)
+        self.loop = BaseSelectorEventLoopForTest(self.selector)
         self.set_event_loop(self.loop)
 
     def test_make_socket_transport(self):

--- a/tests/python/test_subprocess.py
+++ b/tests/python/test_subprocess.py
@@ -26,7 +26,7 @@ PROGRAM_CAT = [
 ]
 
 
-class TestSubprocessTransport(base_subprocess.BaseSubprocessTransport):
+class SubprocessTransportForTest(base_subprocess.BaseSubprocessTransport):
     def _start(self, *args, **kwargs):
         self._proc = mock.Mock()
         self._proc.stdin = None
@@ -44,7 +44,7 @@ class SubprocessTransportTests(test_utils.TestCase):
         protocol = mock.Mock()
         protocol.connection_made._is_coroutine = False
         protocol.process_exited._is_coroutine = False
-        transport = TestSubprocessTransport(
+        transport = SubprocessTransportForTest(
             self.loop, protocol, ['test'], False, None, None, None, 0, waiter=waiter
         )
         return (transport, protocol)

--- a/trio_asyncio/async_.py
+++ b/trio_asyncio/async_.py
@@ -16,7 +16,7 @@ class TrioEventLoop(BaseTrioEventLoop):
 
     def _queue_handle(self, handle):
         self._check_closed()
-        self._q.put_nowait(handle)
+        self._q_send.send_nowait(handle)
         return handle
 
     def default_exception_handler(self, context):

--- a/trio_asyncio/sync.py
+++ b/trio_asyncio/sync.py
@@ -68,7 +68,7 @@ class SyncTrioEventLoop(BaseTrioEventLoop):
 
         def put(self, handle):
             self._some_deferred -= 1
-            self._q.put_nowait(handle)
+            self._q_send.send_nowait(handle)
 
         # If we don't have a token, the main loop is not yet running
         # thus we can't have a race condition.
@@ -81,7 +81,7 @@ class SyncTrioEventLoop(BaseTrioEventLoop):
             self._some_deferred += 1
             self._token.run_sync_soon(put, self, handle)
         else:
-            self._q.put_nowait(handle)
+            self._q_send.send_nowait(handle)
         return handle
 
     def run_forever(self):


### PR DESCRIPTION
Closes #46.

Releasing a new version of `trio-asyncio` with this change will unblock python-trio/pytest-trio#68 - cc @njsmith 