### PR TITLE
Allow multiple calls to loop.stop

### DIFF
--- a/newsfragments/58.bugfix.rst
+++ b/newsfragments/58.bugfix.rst
@@ -1,0 +1,2 @@
+Calling ``loop.stop`` manually no longer causes a deadlock when
+exiting the context of ``trio_asyncio.open_loop``

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -27,6 +27,15 @@ class TestMisc:
                 await loop.wait_closed()
 
     @pytest.mark.trio
+    async def test_too_many_stops(self):
+        with trio.move_on_after(1) as scope:
+            async with trio_asyncio.open_loop() as loop:
+                await trio.hazmat.checkpoint()
+                loop.stop()
+        assert not scope.cancelled_caught, \
+            "Possible deadlock after manual call to loop.stop"
+
+    @pytest.mark.trio
     async def test_err1(self, loop):
         async def raise_err():
             raise RuntimeError("Foo")

--- a/trio_asyncio/async_.py
+++ b/trio_asyncio/async_.py
@@ -60,7 +60,9 @@ class TrioEventLoop(BaseTrioEventLoop):
 
         """
         if waiter is None:
-            waiter = trio.Event()
+            if self._stop_wait is not None:
+                return self._stop_wait
+            waiter = self._stop_wait = trio.Event()
         else:
             waiter.clear()
 

--- a/trio_asyncio/base.py
+++ b/trio_asyncio/base.py
@@ -172,6 +172,8 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         self._stopped = trio.Event()
         self._stopped.set()
 
+        self._stop_wait = None
+
     def __repr__(self):
         try:
             return "<%s running=%s at 0x%x>" % (


### PR DESCRIPTION
Calling loop.stop and then immediately proceeding to exit the
`open_loop`'s context (without hitting any checkpoints) causes the
program to hang forever

Fix by reusing the same `waiter` event across multiple calls to `stop`

Fixes #58