### PR TITLE
Remove invalid escape sequences from docstrings

### DIFF
--- a/trio_asyncio/base.py
+++ b/trio_asyncio/base.py
@@ -551,12 +551,12 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         ready for reading.
 
         This creates a new Trio task. You may want to use "await
-        :obj:`trio.hazmat.wait_readable`\ (fd)" instead, or
+        :obj:`trio.hazmat.wait_readable` (fd)" instead, or
 
         :param fd: Either an integer (Unix file descriptor) or an object
                    with a ``fileno`` method providing one.
         :return: A handle. To remove the listener, either call
-                 ``handle.cancel()`` or :meth:`.remove_reader`\ (fd).
+                 ``handle.cancel()`` or :meth:`.remove_reader` (fd).
         """
         self._ensure_fd_no_transport(fd)
         return self._add_reader(fd, callback, *args)
@@ -604,12 +604,12 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         ready for writing.
 
         This creates a new Trio task. You may want to use "await
-        :obj:`trio.hazmat.wait_writable`\ (fd) instead, or
+        :obj:`trio.hazmat.wait_writable` (fd) instead, or
 
         :param fd: Either an integer (Unix file descriptor) or an object
                    with a ``fileno`` method providing one.
         :return: A handle. To remove the listener, either call
-                 ``handle.cancel()`` or :meth:`remove_writer`\ (fd).
+                 ``handle.cancel()`` or :meth:`remove_writer` (fd).
         """
         self._ensure_fd_no_transport(fd)
         return self._add_writer(fd, callback, *args)


### PR DESCRIPTION
Otherwise these get reported as DeprecationWarning.