### PR TITLE
Update MANIFEST.in to include project metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,6 @@
-include README.rst
+include README.rst LICENSE* CODE_OF_CONDUCT* CONTRIBUTING*
+include .coveragerc
 include ci/test-requirements.txt
 recursive-include tests *.pem
+recursive-include docs *
+prune docs/build


### PR DESCRIPTION
Fixes #75.

I'm not sure how the previous releases included the license files, since they don't appear to have ever been listed in the manifest, but I verified that a new `python setup.py sdist` does include them where it did not before this change.