### PR TITLE
Streamline handling of async loop exit

### DIFF
--- a/newsfragments/80.bugfix.rst
+++ b/newsfragments/80.bugfix.rst
@@ -1,0 +1,4 @@
+Previously, cancelling the context surrounding an :func:`open_loop`
+block might cause a deadlock in some cases. The ordering of operations
+during loop teardown has been improved, so this shouldn't happen
+anymore.

--- a/trio_asyncio/_base.py
+++ b/trio_asyncio/_base.py
@@ -690,10 +690,13 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
             # The shield here ensures that if the context surrounding
             # the loop is cancelled, we keep processing callbacks
             # until we reach the callback inserted by stop().
-            # There's a call to stop() in the finally block of
-            # open_loop(), and we're not shielding the body of the
-            # open_loop() context, so this should be safe against
-            # deadlocks.
+            # That's important to maintain the asyncio invariant
+            # that everything you schedule before stop() will run
+            # before the loop stops. In order to be safe against
+            # deadlocks, it's important that the surrounding
+            # context ensure that stop() gets called upon a
+            # cancellation. (open_loop() does this indirectly
+            # by calling _main_loop_exit().)
             with trio.CancelScope(shield=True):
                 while not self._stopped.is_set():
                     await self._main_loop_one()
@@ -754,12 +757,19 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
             return
 
         with trio.CancelScope(shield=True):
+            # wait_stopped() will return once _main_loop() exits.
+            # stop() inserts a callback that will cause such, and
+            # _main_loop() doesn't block except to wait for new
+            # callbacks to be added, so this should be deadlock-proof.
             self.stop()
             await self.wait_stopped()
 
             # Drain all remaining callbacks, even those after an initial
-            # call to stop(). This avoids a deadlock if stop() was called
-            # again during unwinding.
+            # call to stop(). This avoids deadlocks in some cases if
+            # work is submitted to the loop after the shutdown process
+            # starts. TODO: figure out precisely what this helps with,
+            # maybe find a better way. test_wrong_context_manager_order
+            # deadlocks if we remove it for now.
             while True:
                 try:
                     await self._main_loop_one(no_wait=True)

--- a/trio_asyncio/_base.py
+++ b/trio_asyncio/_base.py
@@ -687,8 +687,16 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         sniffio.current_async_library_cvar.set("asyncio")
 
         try:
-            while not self._stopped.is_set():
-                await self._main_loop_one()
+            # The shield here ensures that if the context surrounding
+            # the loop is cancelled, we keep processing callbacks
+            # until we reach the callback inserted by stop().
+            # There's a call to stop() in the finally block of
+            # open_loop(), and we're not shielding the body of the
+            # open_loop() context, so this should be safe against
+            # deadlocks.
+            with trio.CancelScope(shield=True):
+                while not self._stopped.is_set():
+                    await self._main_loop_one()
         except StopAsyncIteration:
             # raised by .stop_me() to interrupt the loop
             pass
@@ -745,16 +753,20 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         if self._closed:
             return
 
-        self.stop()
-        await self.wait_stopped()
+        with trio.CancelScope(shield=True):
+            self.stop()
+            await self.wait_stopped()
 
-        while True:
-            try:
-                await self._main_loop_one(no_wait=True)
-            except trio.WouldBlock:
-                break
-            except StopAsyncIteration:
-                pass
+            # Drain all remaining callbacks, even those after an initial
+            # call to stop(). This avoids a deadlock if stop() was called
+            # again during unwinding.
+            while True:
+                try:
+                    await self._main_loop_one(no_wait=True)
+                except trio.WouldBlock:
+                    break
+                except StopAsyncIteration:
+                    pass
 
         # Kill off unprocessed work
         self._cancel_fds()

--- a/trio_asyncio/_loop.py
+++ b/trio_asyncio/_loop.py
@@ -389,7 +389,6 @@ async def open_loop(queue_len=None):
     """
 
     # TODO: make sure that there is no asyncio loop already running
-
     async with trio.open_nursery() as nursery:
         loop = TrioEventLoop(queue_len=queue_len)
         old_loop = current_loop.set(loop)


### PR DESCRIPTION
I ran into some deadlocks and other issues ("loop must be stopped before it can be closed" during teardown) while writing tests for #76 that cancelled the open_loop() block. This fixes them, doesn't break anything else, and seems like a good idea in theory.