### PR TITLE
Updates for Trio 0.15

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,8 +4,6 @@ os: Visual Studio 2015
 
 environment:
   matrix:
-    #- PYTHON: "C:\\Python35"
-    #- PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -26,5 +26,5 @@ test_script:
   - "cd empty"
   # Make sure it's being imported from where we expect
   - "python -c \"import os, trio_asyncio; print(os.path.dirname(trio_asyncio.__file__))\""
-  - "python -u -m pytest -W error -ra -v -s --cov=trio_asyncio --cov-config=../.coveragerc ../tests"
+  - "python -u -m pytest -ra -v -s --cov=trio_asyncio --cov-config=../.coveragerc ../tests"
   - "codecov"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,6 +8,8 @@ environment:
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38"
+    - PYTHON: "C:\\Python38-x64"
 
 build_script:
   - "git --no-pager log -n2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.7-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,13 @@ matrix:
     - python: nightly
     - os: osx
       language: generic
-      env: MACPYTHON=3.6.3
+      env: MACPYTHON=3.6.8  # last binary release
+    - os: osx
+      language: generic
+      env: MACPYTHON=3.7.7  # last binary release
+    - os: osx
+      language: generic
+      env: MACPYTHON=3.8.3
     - python: 3.6
       env: CHECK_DOCS=1
     - python: 3.6

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@
 **trio-asyncio** is a re-implementation of the ``asyncio`` mainloop on top of
 Trio.
 
-trio-asyncio requires at least Python 3.5.3. It is tested on recent versions of
-3.5, 3.6, 3.7, 3.8, and nightly.
+Trio-Asyncio requires at least Python 3.6. It is tested on recent versions of
+3.6, 3.7, 3.8, and nightly.
 
 +++++++++++
  Rationale

--- a/ci/travis.sh
+++ b/ci/travis.sh
@@ -6,7 +6,7 @@ set -ex
 YAPF_VERSION=0.20.0
 
 if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-    curl -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.6.pkg
+    curl -Lo macpython.pkg https://www.python.org/ftp/python/${MACPYTHON}/python-${MACPYTHON}-macosx10.9.pkg
     sudo installer -pkg macpython.pkg -target /
     ls /Library/Frameworks/Python.framework/Versions/*/bin/
     PYTHON_EXE=/Library/Frameworks/Python.framework/Versions/*/bin/python3

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -51,7 +51,7 @@ asyncio libraries such as ``home-assistant``.
 Helpful facts:
 
 * Supported environments: Linux, MacOS, or Windows running some kind of Python
-  3.5.3-or-better (either CPython or PyPy3 is fine). \*BSD and illumOS likely
+  3.6-or-better (either CPython or PyPy3 is fine). \*BSD and illumOS likely
   work too, but are untested.
 
 * Install: ``python3 -m pip install -U trio-asyncio`` (or on Windows, maybe

--- a/docs/source/principles.rst
+++ b/docs/source/principles.rst
@@ -81,7 +81,7 @@ Most *synchronous* asyncio or Trio functions (:meth:`trio.Event.set`,
 asyncio or Trio context, and work equally well regardless of the
 flavor of function calling them. The exceptions are functions that
 access the current task (:func:`asyncio.current_task`,
-:func:`trio.hazmat.current_task`, and anything that calls them),
+:func:`trio.lowlevel.current_task`, and anything that calls them),
 because there's only a meaningful concept of the current *foo* task
 when a *foo*-flavored function is executing.  For example, this means
 context managers that set a timeout on their body (``with

--- a/newsfragments/82.misc.rst
+++ b/newsfragments/82.misc.rst
@@ -1,0 +1,3 @@
+``trio-asyncio`` now requires Trio 0.15.
+
+Support for Python < 3.6 has been removed.

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,6 @@ max-line-length=99
 ignore=E402,E731,E127,E502,E123,W503
 [tool:pytest]
 addopts = -p no:asyncio
+filterwarnings =
+    error
+    ignore:The loop argument is deprecated*:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     python_requires=">=3.6",  # temporary, for RTD
     keywords=["async", "io", "trio", "asyncio", "trio-asyncio"],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest >= 5.4', 'outcome'],
+    tests_require=['pytest >= 5.4', 'pytest-trio >= 0.6', 'outcome'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     python_requires=">=3.6",  # temporary, for RTD
     keywords=["async", "io", "trio", "asyncio", "trio-asyncio"],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'outcome'],
+    tests_require=['pytest >= 5.4', 'outcome'],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ This works rather well: ``trio_asyncio`` consists of just ~700 lines of
 code (asyncio: ~8000) but passes the complete Python 3.6 test suite with no
 errors.
 
-``trio_asyncio`` requires Python 3.5.3 or better.
+``trio_asyncio`` requires Python 3.6 or better.
 
 Author
 ======
@@ -53,12 +53,12 @@ Matthias Urlichs <matthias@urlichs.de>
 """
 
 install_requires = [
-    "trio >= 0.12.0",
-    "async_generator >= 1.6",
+    "trio >= 0.13.0",
     "outcome",
 ]
 if sys.version_info < (3, 7):
     install_requires.append("contextvars >= 2.1")
+    install_requires.append("async_generator >= 1.6")
 
 setup(
     name="trio_asyncio",
@@ -74,7 +74,7 @@ setup(
     # This means, just install *everything* you see under trio/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
-    python_requires=">=3.5.2",  # temporary, for RTD
+    python_requires=">=3.6",  # temporary, for RTD
     keywords=["async", "io", "trio", "asyncio", "trio-asyncio"],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'outcome'],

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ Matthias Urlichs <matthias@urlichs.de>
 """
 
 install_requires = [
-    "trio >= 0.13.0",
+    "trio >= 0.15.0",
     "outcome",
 ]
 if sys.version_info < (3, 7):

--- a/tests/aiotest/test_callback.py
+++ b/tests/aiotest/test_callback.py
@@ -45,7 +45,8 @@ class TestCallback(aiotest.TestCase):
         await loop.stop().wait()
         loop.close()
 
-        async def test():
+        @config.asyncio.coroutine
+        def test():
             pass
 
         func = lambda: False

--- a/tests/aiotest/test_callback.py
+++ b/tests/aiotest/test_callback.py
@@ -45,8 +45,7 @@ class TestCallback(aiotest.TestCase):
         await loop.stop().wait()
         loop.close()
 
-        @config.asyncio.coroutine
-        def test():
+        async def test():
             pass
 
         func = lambda: False

--- a/tests/aiotest/test_coroutine.py
+++ b/tests/aiotest/test_coroutine.py
@@ -7,7 +7,7 @@ from .. import utils as test_utils
 async def hello_world(asyncio, result, delay, loop):
     result.append("Hello")
     # retrieve the event loop from the policy
-    await asyncio.sleep(delay)
+    await asyncio.sleep(delay, loop=loop)
     result.append('World')
     return "."
 

--- a/tests/aiotest/test_coroutine.py
+++ b/tests/aiotest/test_coroutine.py
@@ -7,7 +7,7 @@ from .. import utils as test_utils
 async def hello_world(asyncio, result, delay, loop):
     result.append("Hello")
     # retrieve the event loop from the policy
-    await asyncio.sleep(delay, loop=loop)
+    await asyncio.sleep(delay)
     result.append('World')
     return "."
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import pytest
 import asyncio
 import trio_asyncio
 import inspect
-from async_generator import async_generator, yield_
 
 # Hacks for <3.7
 if not hasattr(asyncio, 'run'):
@@ -45,11 +44,10 @@ if not hasattr(asyncio, 'create_task'):
 
 
 @pytest.fixture
-@async_generator
 async def loop():
     async with trio_asyncio.open_loop() as loop:
         try:
-            await yield_(loop)
+            yield loop
         finally:
             await loop.stop().wait()
 

--- a/tests/interop/test_adapter.py
+++ b/tests/interop/test_adapter.py
@@ -1,5 +1,4 @@
 import pytest
-from async_generator import async_generator, yield_
 from trio_asyncio import aio_as_trio, trio_as_aio, allow_asyncio
 from trio_asyncio import aio2trio, trio2aio
 import asyncio
@@ -8,7 +7,10 @@ import sniffio
 from tests import aiotest
 import sys
 import warnings
-from async_generator import asynccontextmanager
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    from async_generator import asynccontextmanager
 from .. import utils as test_utils
 from trio_asyncio import TrioAsyncioDeprecationWarning
 
@@ -74,43 +76,39 @@ class SomeThing:
         self.flag |= 1
         return 4
 
-    @async_generator
     async def iter_asyncio(self, do_test=True):
         if do_test and sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
         await asyncio.sleep(0.01, loop=self.loop)
-        await yield_(1)
+        yield 1
         await asyncio.sleep(0.01, loop=self.loop)
-        await yield_(2)
+        yield 2
         await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
 
-    @async_generator
     async def iter_trio(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "trio"
         await trio.sleep(0.01)
-        await yield_(1)
+        yield 1
         await trio.sleep(0.01)
-        await yield_(2)
+        yield 2
         await trio.sleep(0.01)
         self.flag |= 1
 
     @asynccontextmanager
-    @async_generator
     async def ctx_asyncio(self):
         await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
-        await yield_(self)
+        yield self
         await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 2
 
     @asynccontextmanager
-    @async_generator
     async def ctx_trio(self):
         await trio.sleep(0.01)
         self.flag |= 1
-        await yield_(self)
+        yield self
         await trio.sleep(0.01)
         self.flag |= 2
 

--- a/tests/interop/test_adapter.py
+++ b/tests/interop/test_adapter.py
@@ -57,7 +57,7 @@ class SomeThing:
     async def dly_asyncio_depr(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
         return 4
 
@@ -65,25 +65,25 @@ class SomeThing:
     async def dly_asyncio_adapted(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
         return 4
 
     async def dly_asyncio(self, do_test=True):
         if do_test and sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
         return 4
 
     async def iter_asyncio(self, do_test=True):
         if do_test and sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         yield 1
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         yield 2
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
 
     async def iter_trio(self):
@@ -98,10 +98,10 @@ class SomeThing:
 
     @asynccontextmanager
     async def ctx_asyncio(self):
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 1
         yield self
-        await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01, loop=self.loop)
         self.flag |= 2
 
     @asynccontextmanager

--- a/tests/interop/test_adapter.py
+++ b/tests/interop/test_adapter.py
@@ -57,7 +57,7 @@ class SomeThing:
     async def dly_asyncio_depr(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.flag |= 1
         return 4
 
@@ -65,25 +65,25 @@ class SomeThing:
     async def dly_asyncio_adapted(self):
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.flag |= 1
         return 4
 
     async def dly_asyncio(self, do_test=True):
         if do_test and sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.flag |= 1
         return 4
 
     async def iter_asyncio(self, do_test=True):
         if do_test and sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         yield 1
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         yield 2
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.flag |= 1
 
     async def iter_trio(self):
@@ -98,10 +98,10 @@ class SomeThing:
 
     @asynccontextmanager
     async def ctx_asyncio(self):
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.flag |= 1
         yield self
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.flag |= 2
 
     @asynccontextmanager

--- a/tests/interop/test_calls.py
+++ b/tests/interop/test_calls.py
@@ -2,7 +2,6 @@ import pytest
 import asyncio
 import trio
 import sniffio
-from async_generator import async_generator, yield_
 from trio_asyncio import aio_as_trio, trio_as_aio
 from tests import aiotest
 from functools import partial
@@ -526,11 +525,10 @@ class TestCalls(aiotest.TestCase):
 
     @pytest.mark.trio
     async def test_trio_asyncio_generator(self, loop):
-        @async_generator
         async def dly_asyncio():
-            await yield_(1)
+            yield 1
             await asyncio.sleep(0.01, loop=loop)
-            await yield_(2)
+            yield 2
 
         with test_utils.deprecate(self):
             res = await async_gen_to_list(loop.wrap_generator(dly_asyncio))
@@ -538,11 +536,10 @@ class TestCalls(aiotest.TestCase):
 
     @pytest.mark.trio
     async def test_trio_asyncio_generator_with_error(self, loop):
-        @async_generator
         async def dly_asyncio():
-            await yield_(1)
+            yield 1
             raise RuntimeError("I has an owie")
-            await yield_(2)
+            yield 2
 
         with test_utils.deprecate(self):
             with pytest.raises(RuntimeError) as err:
@@ -551,9 +548,8 @@ class TestCalls(aiotest.TestCase):
 
     @pytest.mark.trio
     async def test_trio_asyncio_generator_with_cancellation(self, loop):
-        @async_generator
         async def dly_asyncio(hold, seen):
-            await yield_(1)
+            yield 1
             seen.flag |= 1
             await hold.wait()
 
@@ -573,11 +569,10 @@ class TestCalls(aiotest.TestCase):
 
     @pytest.mark.trio
     async def test_trio_asyncio_iterator(self, loop):
-        @async_generator
         async def slow_nums():
             for n in range(1, 6):
                 await asyncio.sleep(0.01, loop=loop)
-                await yield_(n)
+                yield n
 
         sum = 0
         async for n in aio_as_trio(slow_nums()):
@@ -586,11 +581,10 @@ class TestCalls(aiotest.TestCase):
 
     @pytest.mark.trio
     async def test_trio_asyncio_iterator_depr(self, loop):
-        @async_generator
         async def slow_nums():
             for n in range(1, 6):
                 await asyncio.sleep(0.01, loop=loop)
-                await yield_(n)
+                yield n
 
         sum = 0
         # with test_utils.deprecate(self): ## not yet

--- a/tests/interop/test_calls.py
+++ b/tests/interop/test_calls.py
@@ -48,7 +48,7 @@ class AioContext:
         self.parent.did_it = 1
         if sys.version_info >= (3, 7):
             assert sniffio.current_async_library() == "asyncio"
-        await asyncio.sleep(0.01, loop=self.loop)
+        await asyncio.sleep(0.01)
         self.parent.did_it = 2
         return self
 
@@ -60,7 +60,7 @@ class AioContext:
 class TestCalls(aiotest.TestCase):
     async def call_t_a(self, proc, *args, loop=None):
         """called from Trio"""
-        return await aio_as_trio(proc, loop=loop)(*args)
+        return await aio_as_trio(proc)(*args)
 
     async def call_t_a_depr(self, proc, *args, loop=None):
         """called from Trio"""
@@ -69,7 +69,7 @@ class TestCalls(aiotest.TestCase):
 
     async def call_a_t(self, proc, *args, loop=None):
         """call from asyncio to an async trio function"""
-        return await trio_as_aio(proc, loop=loop)(*args)
+        return await trio_as_aio(proc)(*args)
 
     async def call_a_t_depr(self, proc, *args, loop=None):
         """call from asyncio to an async trio function"""
@@ -83,17 +83,17 @@ class TestCalls(aiotest.TestCase):
     @pytest.mark.trio
     async def test_call_at(self, loop):
         async def delay(t):
-            done = asyncio.Event(loop=loop)
+            done = asyncio.Event()
             loop.call_at(t, done.set)
             await done.wait()
 
         t = loop.time() + 0.1
-        await aio_as_trio(delay, loop=loop)(t)
+        await aio_as_trio(delay)(t)
 
     @pytest.mark.trio
     async def test_call_at_depr(self, loop):
         async def delay(t):
-            done = asyncio.Event(loop=loop)
+            done = asyncio.Event()
             loop.call_at(t, done.set)
             await done.wait()
 
@@ -111,7 +111,7 @@ class TestCalls(aiotest.TestCase):
             return 8
 
         seen = Seen()
-        res = await aio_as_trio(partial(self.call_a_t, loop=loop), loop=loop)(dly_trio, seen)
+        res = await aio_as_trio(partial(self.call_a_t, loop=loop))(dly_trio, seen)
         assert res == 8
         assert seen.flag == 2
 
@@ -125,14 +125,14 @@ class TestCalls(aiotest.TestCase):
             return 8
 
         seen = Seen()
-        res = await aio_as_trio(partial(self.call_a_t_depr, loop=loop), loop=loop)(dly_trio, seen)
+        res = await aio_as_trio(partial(self.call_a_t_depr, loop=loop))(dly_trio, seen)
         assert res == 8
         assert seen.flag == 2
 
     @pytest.mark.trio
     async def test_call_asyncio_ctx(self, loop):
         self.did_it = 0
-        async with aio_as_trio(AioContext(self, loop), loop=loop) as ctx:
+        async with aio_as_trio(AioContext(self, loop)) as ctx:
             assert ctx.parent is self
             assert self.did_it == 2
             self.did_it = 3
@@ -148,7 +148,7 @@ class TestCalls(aiotest.TestCase):
                 self.did_it = 3
             assert self.did_it == 4
 
-        await aio_as_trio(_call_trio_ctx, loop=loop)()
+        await aio_as_trio(_call_trio_ctx)()
 
     @pytest.mark.trio
     async def test_call_trio_ctx_depr(self, loop):
@@ -172,7 +172,7 @@ class TestCalls(aiotest.TestCase):
             return 8
 
         seen = Seen()
-        res = await aio_as_trio(partial(self.call_a_ts, loop=loop), loop=loop)(dly_trio, seen)
+        res = await aio_as_trio(partial(self.call_a_ts, loop=loop))(dly_trio, seen)
         assert res == 8
         assert seen.flag == 2
 
@@ -193,7 +193,7 @@ class TestCalls(aiotest.TestCase):
     @pytest.mark.trio
     async def test_trio_asyncio(self, loop):
         async def dly_asyncio(seen):
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             seen.flag |= 1
             return 4
 
@@ -205,7 +205,7 @@ class TestCalls(aiotest.TestCase):
     @pytest.mark.trio
     async def test_trio_asyncio_depr(self, loop):
         async def dly_asyncio(seen):
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             seen.flag |= 1
             return 4
 
@@ -221,7 +221,7 @@ class TestCalls(aiotest.TestCase):
             raise RuntimeError("I has another owie")
 
         with pytest.raises(RuntimeError) as err:
-            await aio_as_trio(partial(self.call_a_t, loop=loop), loop=loop)(err_trio)
+            await aio_as_trio(partial(self.call_a_t, loop=loop))(err_trio)
         assert err.value.args[0] == "I has another owie"
 
     @pytest.mark.trio
@@ -231,7 +231,7 @@ class TestCalls(aiotest.TestCase):
             raise RuntimeError("I has another owie")
 
         with pytest.raises(RuntimeError) as err:
-            await aio_as_trio(partial(self.call_a_t_depr, loop=loop), loop=loop)(err_trio)
+            await aio_as_trio(partial(self.call_a_t_depr, loop=loop))(err_trio)
         assert err.value.args[0] == "I has another owie"
 
     @pytest.mark.trio
@@ -253,7 +253,8 @@ class TestCalls(aiotest.TestCase):
 
         with pytest.raises(RuntimeError) as err:
             with test_utils.deprecate(self):
-                await loop.run_asyncio(partial(self.call_a_t_depr, loop=loop), err_trio)
+                await loop.run_asyncio(partial(self.call_a_t_depr,
+                    loop=loop), err_trio)
         assert err.value.args[0] == "I has another owie"
 
     @pytest.mark.trio
@@ -263,7 +264,7 @@ class TestCalls(aiotest.TestCase):
             raise RuntimeError("I has more owie")
 
         with pytest.raises(RuntimeError) as err:
-            await aio_as_trio(partial(self.call_a_ts, loop=loop), loop=loop)(err_trio_sync)
+            await aio_as_trio(partial(self.call_a_ts, loop=loop))(err_trio_sync)
         assert err.value.args[0] == "I has more owie"
 
     @pytest.mark.trio
@@ -280,7 +281,7 @@ class TestCalls(aiotest.TestCase):
     @pytest.mark.trio
     async def test_trio_asyncio_error(self, loop):
         async def err_asyncio():
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             raise RuntimeError("I has an owie")
 
         with pytest.raises(RuntimeError) as err:
@@ -290,7 +291,7 @@ class TestCalls(aiotest.TestCase):
     @pytest.mark.trio
     async def test_trio_asyncio_error_depr(self, loop):
         async def err_asyncio():
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             raise RuntimeError("I has an owie")
 
         with pytest.raises(RuntimeError) as err:
@@ -310,21 +311,21 @@ class TestCalls(aiotest.TestCase):
 
         seen = Seen()
         with pytest.raises(asyncio.CancelledError):
-            await aio_as_trio(partial(self.call_a_t, loop=loop), loop=loop)(cancelled_trio, seen)
+            await aio_as_trio(partial(self.call_a_t, loop=loop))(cancelled_trio, seen)
         assert seen.flag == 3
 
     @pytest.mark.trio
     async def test_trio_asyncio_cancel_out(self, loop):
         async def cancelled_asyncio(seen):
             seen.flag |= 1
-            await asyncio.sleep(0.01, loop=loop)
-            f = asyncio.Future(loop=loop)
+            await asyncio.sleep(0.01)
+            f = asyncio.Future()
             f.cancel()
             return f.result()  # raises error
 
         def cancelled_future(seen):
             seen.flag |= 1
-            f = asyncio.Future(loop=loop)
+            f = asyncio.Future()
             f.cancel()
             return f  # contains error
 
@@ -347,14 +348,14 @@ class TestCalls(aiotest.TestCase):
     async def test_trio_asyncio_cancel_out_depr(self, loop):
         async def cancelled_asyncio(seen):
             seen.flag |= 1
-            await asyncio.sleep(0.01, loop=loop)
-            f = asyncio.Future(loop=loop)
+            await asyncio.sleep(0.01)
+            f = asyncio.Future()
             f.cancel()
             return f.result()  # raises error
 
         def cancelled_future(seen):
             seen.flag |= 1
-            f = asyncio.Future(loop=loop)
+            f = asyncio.Future()
             f.cancel()
             return f  # contains error
 
@@ -387,7 +388,7 @@ class TestCalls(aiotest.TestCase):
                 seen.flag |= 2
 
         async def cancel_asyncio(seen):
-            started = asyncio.Event(loop=loop)
+            started = asyncio.Event()
             f = asyncio.ensure_future(self.call_a_t(in_trio, started, seen, loop=loop))
             await started.wait()
             f.cancel()
@@ -396,7 +397,7 @@ class TestCalls(aiotest.TestCase):
             seen.flag |= 8
 
         seen = Seen()
-        await aio_as_trio(cancel_asyncio, loop=loop)(seen)
+        await aio_as_trio(cancel_asyncio)(seen)
         assert seen.flag == 1 | 2 | 8
 
     @pytest.mark.trio
@@ -404,7 +405,7 @@ class TestCalls(aiotest.TestCase):
         async def in_asyncio(started, seen):
             started.set()
             try:
-                await asyncio.sleep(9999, loop=loop)
+                await asyncio.sleep(9999)
             except asyncio.CancelledError:
                 seen.flag |= 1
             except trio.Cancelled:
@@ -431,7 +432,7 @@ class TestCalls(aiotest.TestCase):
         async def in_asyncio(started, seen):
             started.set()
             try:
-                await asyncio.sleep(9999, loop=loop)
+                await asyncio.sleep(9999)
             except asyncio.CancelledError:
                 seen.flag |= 1
             except trio.Cancelled:
@@ -527,7 +528,7 @@ class TestCalls(aiotest.TestCase):
     async def test_trio_asyncio_generator(self, loop):
         async def dly_asyncio():
             yield 1
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             yield 2
 
         with test_utils.deprecate(self):
@@ -557,7 +558,7 @@ class TestCalls(aiotest.TestCase):
             await trio.sleep(0.01)
             nursery.cancel_scope.cancel()
 
-        hold = asyncio.Event(loop=loop)
+        hold = asyncio.Event()
         seen = Seen()
 
         with test_utils.deprecate(self):
@@ -571,7 +572,7 @@ class TestCalls(aiotest.TestCase):
     async def test_trio_asyncio_iterator(self, loop):
         async def slow_nums():
             for n in range(1, 6):
-                await asyncio.sleep(0.01, loop=loop)
+                await asyncio.sleep(0.01)
                 yield n
 
         sum = 0
@@ -583,13 +584,11 @@ class TestCalls(aiotest.TestCase):
     async def test_trio_asyncio_iterator_depr(self, loop):
         async def slow_nums():
             for n in range(1, 6):
-                await asyncio.sleep(0.01, loop=loop)
+                await asyncio.sleep(0.01)
                 yield n
 
         sum = 0
         # with test_utils.deprecate(self): ## not yet
-        async for n in aio_as_trio(
-            slow_nums(), loop=loop
-        ):
+        async for n in aio_as_trio(slow_nums()):
             sum += n
         assert sum == 15

--- a/tests/interop/test_calls.py
+++ b/tests/interop/test_calls.py
@@ -302,7 +302,7 @@ class TestCalls(aiotest.TestCase):
         async def cancelled_trio(seen):
             seen.flag |= 1
             await trio.sleep(0.01)
-            scope = trio.hazmat.current_task()._cancel_status._scope
+            scope = trio.lowlevel.current_task()._cancel_status._scope
             scope.cancel()
             seen.flag |= 2
             await trio.sleep(0.01)

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -21,7 +21,11 @@ else:
     # to the event loop in the testsuite class, because
     # SyncTrioEventLoop spawns a thread that only exits when the
     # loop is closed. Nerf it.
-    from test.support import threading_cleanup
+    try:
+        from test.support import threading_cleanup
+    except ImportError:
+        # Python 3.10+
+        from test.support.threading_helper import threading_cleanup
 
     def threading_no_cleanup(*original_values):
         pass

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -124,7 +124,7 @@ else:
 
         # These fail with ConnectionResetError on Pythons <= 3.7.x
         # for some unknown x. (3.7.1 fails, 3.7.5 and 3.7.6 pass;
-        # older 3.6.x also affected, and older-or-all 3.5.x)
+        # older 3.6.x also affected)
         if sys.platform != "win32" and sys.version_info < (3, 8):
             import selectors
 

--- a/tests/test_aio_subprocess.py
+++ b/tests/test_aio_subprocess.py
@@ -20,12 +20,12 @@ class MySubprocessProtocol(asyncio.SubprocessProtocol):
     def __init__(self, loop):
         self.state = 'INITIAL'
         self.transport = None
-        self.connected = asyncio.Future(loop=loop)
-        self.completed = asyncio.Future(loop=loop)
-        self.disconnects = {fd: asyncio.Future(loop=loop) for fd in range(3)}
+        self.connected = asyncio.Future()
+        self.completed = asyncio.Future()
+        self.disconnects = {fd: asyncio.Future() for fd in range(3)}
         self.data = {1: b'', 2: b''}
         self.returncode = None
-        self.got_data = {1: asyncio.Event(loop=loop), 2: asyncio.Event(loop=loop)}
+        self.got_data = {1: asyncio.Event(), 2: asyncio.Event()}
 
     def connection_made(self, transport):
         self.transport = transport

--- a/tests/test_aio_subprocess.py
+++ b/tests/test_aio_subprocess.py
@@ -20,12 +20,12 @@ class MySubprocessProtocol(asyncio.SubprocessProtocol):
     def __init__(self, loop):
         self.state = 'INITIAL'
         self.transport = None
-        self.connected = asyncio.Future()
-        self.completed = asyncio.Future()
-        self.disconnects = {fd: asyncio.Future() for fd in range(3)}
+        self.connected = asyncio.Future(loop=loop)
+        self.completed = asyncio.Future(loop=loop)
+        self.disconnects = {fd: asyncio.Future(loop=loop) for fd in range(3)}
         self.data = {1: b'', 2: b''}
         self.returncode = None
-        self.got_data = {1: asyncio.Event(), 2: asyncio.Event()}
+        self.got_data = {1: asyncio.Event(loop=loop), 2: asyncio.Event(loop=loop)}
 
     def connection_made(self, transport):
         self.transport = transport

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -30,7 +30,7 @@ class TestMisc:
     async def test_too_many_stops(self):
         with trio.move_on_after(1) as scope:
             async with trio_asyncio.open_loop() as loop:
-                await trio.hazmat.checkpoint()
+                await trio.lowlevel.checkpoint()
                 loop.stop()
         assert not scope.cancelled_caught, \
             "Possible deadlock after manual call to loop.stop"

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -167,7 +167,7 @@ class TestMisc:
         with pytest.raises(RuntimeError):
             trio_asyncio.run_trio_task(nest, 100)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises((AttributeError, RuntimeError)):
             with trio_asyncio.open_loop():
                 nest(1000)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -167,7 +167,7 @@ class TestMisc:
         with pytest.raises(RuntimeError):
             trio_asyncio.run_trio_task(nest, 100)
 
-        with pytest.raises(AttributeError):
+        with pytest.raises(RuntimeError):
             with trio_asyncio.open_loop():
                 nest(1000)
 
@@ -263,9 +263,9 @@ class TestMisc:
 
         async def cancel_sleep():
             h = loop.call_later(0.2, do_not_run)
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(0.1, loop=loop)
             h.cancel()
-            await asyncio.sleep(0.3)
+            await asyncio.sleep(0.3, loop=loop)
 
         await trio_asyncio.aio_as_trio(cancel_sleep, loop=loop)()
         assert owch == 0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -167,7 +167,7 @@ class TestMisc:
         with pytest.raises(RuntimeError):
             trio_asyncio.run_trio_task(nest, 100)
 
-        with pytest.raises(RuntimeError):
+        with pytest.raises(AttributeError):
             with trio_asyncio.open_loop():
                 nest(1000)
 
@@ -263,9 +263,9 @@ class TestMisc:
 
         async def cancel_sleep():
             h = loop.call_later(0.2, do_not_run)
-            await asyncio.sleep(0.1, loop=loop)
+            await asyncio.sleep(0.1)
             h.cancel()
-            await asyncio.sleep(0.3, loop=loop)
+            await asyncio.sleep(0.3)
 
         await trio_asyncio.aio_as_trio(cancel_sleep, loop=loop)()
         assert owch == 0

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -1,0 +1,47 @@
+import pytest
+import sys
+import asyncio
+from async_generator import async_generator, yield_
+import trio_asyncio
+
+
+async def use_asyncio():
+    await trio_asyncio.aio_as_trio(asyncio.sleep)(0)
+
+
+@pytest.fixture()
+@async_generator
+async def asyncio_loop():
+    async with trio_asyncio.open_loop() as loop:
+        await yield_(loop)
+
+
+@pytest.fixture()
+@async_generator
+async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
+    await use_asyncio()
+    await yield_()
+
+
+@pytest.fixture()
+@async_generator
+async def asyncio_fixture_own_loop():
+    async with trio_asyncio.open_loop():
+        await use_asyncio()
+        await yield_()
+
+
+@pytest.mark.trio
+async def test_no_fixture():
+    async with trio_asyncio.open_loop():
+        await use_asyncio()
+
+
+@pytest.mark.trio
+async def test_half_fixtured_asyncpg_conn(asyncio_fixture_own_loop):
+    await use_asyncio()
+
+
+@pytest.mark.trio
+async def test_fixtured_asyncpg_conn(asyncio_fixture_with_fixtured_loop):
+    await use_asyncio()

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -10,25 +10,16 @@ async def use_asyncio():
 
 
 @pytest.fixture()
-@async_generator
-async def asyncio_loop():
-    async with trio_asyncio.open_loop() as loop:
-        await yield_(loop)
-
-
-@pytest.fixture()
-@async_generator
-async def asyncio_fixture_with_fixtured_loop(asyncio_loop):
+async def asyncio_fixture_with_fixtured_loop(loop):
     await use_asyncio()
-    await yield_()
+    yield None
 
 
 @pytest.fixture()
-@async_generator
 async def asyncio_fixture_own_loop():
     async with trio_asyncio.open_loop():
         await use_asyncio()
-        await yield_()
+        yield None
 
 
 @pytest.mark.trio

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,44 @@
+[tox]
+envlist = py36,py37
+
+[sphinx-vars]
+build_dir = build
+input_dir = docs/source
+sphinxopts = -a -W -b html
+autosphinxopts = -i *~ -i *.sw* -i Makefile*
+sphinxbuilddir = {[sphinx-vars]build_dir}/sphinx/html
+allsphinxopts = -d {[sphinx-vars]build_dir}/sphinx/doctrees {[sphinx-vars]sphinxopts} docs
+
+[testenv]
+deps =
+  pytest
+  outcome
+commands =
+  pytest -xvvv --full-trace
+
+[testenv:pylint]
+deps =
+  pylint
+commands =
+  pylint trio_asyncio
+
+[testenv:flake8]
+deps =
+    flake8
+commands =
+    flake8 trio_asyncio tests
+
+[testenv:doc]
+deps =
+  sphinx
+  sphinx-rtd-theme
+  sphinxcontrib-trio
+commands =
+  sphinx-build -a {[sphinx-vars]input_dir} {[sphinx-vars]build_dir}
+
+[testenv:livehtml]
+deps =
+  sphinx
+  sphinx-autobuild
+commands =
+  sphinx-autobuild {[sphinx-vars]autosphinxopts} {[sphinx-vars]allsphinxopts} {[sphinx-vars]sphinxbuilddir}

--- a/trio_asyncio/_base.py
+++ b/trio_asyncio/_base.py
@@ -17,7 +17,7 @@ from . import _util
 from selectors import _BaseSelectorImpl, EVENT_READ, EVENT_WRITE
 
 try:
-    from trio.hazmat import wait_for_child
+    from trio.lowlevel import wait_for_child
 except ImportError:
     from ._child import wait_for_child
 
@@ -27,11 +27,11 @@ logger = logging.getLogger(__name__)
 _mswindows = (sys.platform == "win32")
 
 try:
-    _wait_readable = trio.hazmat.wait_readable
-    _wait_writable = trio.hazmat.wait_writable
+    _wait_readable = trio.lowlevel.wait_readable
+    _wait_writable = trio.lowlevel.wait_writable
 except AttributeError:
-    _wait_readable = trio.hazmat.wait_socket_readable
-    _wait_writable = trio.hazmat.wait_socket_writable
+    _wait_readable = trio.lowlevel.wait_socket_readable
+    _wait_writable = trio.lowlevel.wait_socket_writable
 
 
 class _Clear:
@@ -466,7 +466,7 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         ready for reading.
 
         This creates a new Trio task. You may want to use "await
-        :obj:`trio.hazmat.wait_readable` (fd)" instead, or
+        :obj:`trio.lowlevel.wait_readable` (fd)" instead, or
 
         :param fd: Either an integer (Unix file descriptor) or an object
                    with a ``fileno`` method providing one.
@@ -516,7 +516,7 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         ready for writing.
 
         This creates a new Trio task. You may want to use "await
-        :obj:`trio.hazmat.wait_writable` (fd) instead, or
+        :obj:`trio.lowlevel.wait_writable` (fd) instead, or
 
         :param fd: Either an integer (Unix file descriptor) or an object
                    with a ``fileno`` method providing one.
@@ -614,8 +614,8 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
         if self._nursery is not None or not self._stopped.is_set():
             raise RuntimeError("You can't enter a loop twice")
         self._nursery = nursery
-        self._task = trio.hazmat.current_task()
-        self._token = trio.hazmat.current_trio_token()
+        self._task = trio.lowlevel.current_task()
+        self._token = trio.lowlevel.current_trio_token()
 
     async def _main_loop(self, task_status=trio.TASK_STATUS_IGNORED):
         """Run the loop by processing its event queue.

--- a/trio_asyncio/_child.py
+++ b/trio_asyncio/_child.py
@@ -96,7 +96,7 @@ class ProcessWaiter:
     async def _start_waiting(self):
         """Start the background thread that waits for a specific child"""
         self.__event = trio.Event()
-        self.__token = trio.hazmat.current_trio_token()
+        self.__token = trio.lowlevel.current_trio_token()
 
         self.__thread = threading.Thread(
             target=self._wait_thread, name="waitpid_%d" % self.__pid, daemon=True

--- a/trio_asyncio/_loop.py
+++ b/trio_asyncio/_loop.py
@@ -8,7 +8,10 @@ import warnings
 import threading
 from contextvars import ContextVar
 
-from async_generator import async_generator, yield_, asynccontextmanager
+try:
+    from contextlib import asynccontextmanager
+except ImportError:
+    from async_generator import asynccontextmanager
 
 from ._util import run_aio_future, run_aio_generator
 from ._async import TrioEventLoop
@@ -368,7 +371,6 @@ class TrioChildWatcher(asyncio.AbstractChildWatcher if sys.platform != 'win32' e
 
 
 @asynccontextmanager
-@async_generator
 async def open_loop(queue_len=None):
     """Returns a Trio-flavored async context manager which provides
     an asyncio event loop running on top of Trio.
@@ -396,7 +398,7 @@ async def open_loop(queue_len=None):
             loop._closed = False
             await loop._main_loop_init(nursery)
             await nursery.start(loop._main_loop)
-            await yield_(loop)
+            yield loop
         finally:
             try:
                 await loop._main_loop_exit()

--- a/trio_asyncio/_loop.py
+++ b/trio_asyncio/_loop.py
@@ -18,7 +18,7 @@ from ._async import TrioEventLoop
 from ._deprecate import deprecated, warn_deprecated
 
 try:
-    from trio.hazmat import wait_for_child
+    from trio.lowlevel import wait_for_child
 except ImportError:
     from ._child import wait_for_child
 
@@ -103,7 +103,7 @@ _faked_policy = _FakedPolicy()
 
 def _in_trio_context():
     try:
-        trio.hazmat.current_task()
+        trio.lowlevel.current_task()
     except RuntimeError:
         return False
     else:
@@ -147,7 +147,7 @@ class _TrioPolicy(asyncio.events.BaseDefaultEventLoopPolicy):
         ``.current_event_loop`` property.
         """
         try:
-            task = trio.hazmat.current_task()
+            task = trio.lowlevel.current_task()
         except RuntimeError:
             pass
         else:
@@ -230,7 +230,7 @@ else:
 
     def _new_run_get():
         try:
-            task = trio.hazmat.current_task()
+            task = trio.lowlevel.current_task()
         except RuntimeError:
             pass
         else:

--- a/trio_asyncio/_util.py
+++ b/trio_asyncio/_util.py
@@ -23,11 +23,11 @@ async def run_aio_future(future):
     This is a Trio-flavored async function.
 
     """
-    task = trio.hazmat.current_task()
+    task = trio.lowlevel.current_task()
     raise_cancel = None
 
     def done_cb(_):
-        trio.hazmat.reschedule(task, outcome.capture(future.result))
+        trio.lowlevel.reschedule(task, outcome.capture(future.result))
 
     future.add_done_callback(done_cb)
 
@@ -38,10 +38,10 @@ async def run_aio_future(future):
         # Attempt to cancel our future
         future.cancel()
         # Keep waiting
-        return trio.hazmat.Abort.FAILED
+        return trio.lowlevel.Abort.FAILED
 
     try:
-        res = await trio.hazmat.wait_task_rescheduled(abort_cb)
+        res = await trio.lowlevel.wait_task_rescheduled(abort_cb)
         return res
     except asyncio.CancelledError as exc:
         if raise_cancel is not None:
@@ -64,7 +64,7 @@ async def run_aio_generator(loop, async_generator):
     doesn't have to be). The asyncio tasks that perform each iteration
     of *async_generator* will run in *loop*.
     """
-    task = trio.hazmat.current_task()
+    task = trio.lowlevel.current_task()
     raise_cancel = None
     current_read = None
 
@@ -83,7 +83,7 @@ async def run_aio_generator(loop, async_generator):
         finally:
             sniffio.current_async_library_cvar.reset(t)
 
-        trio.hazmat.reschedule(task, result)
+        trio.lowlevel.reschedule(task, result)
 
     def abort_cb(raise_cancel_arg):
         # Save the cancel-raising function
@@ -92,25 +92,25 @@ async def run_aio_generator(loop, async_generator):
 
         if not current_read:
             # There is no current read
-            return trio.hazmat.Abort.SUCCEEDED
+            return trio.lowlevel.Abort.SUCCEEDED
         else:
             # Attempt to cancel the current iterator read, do not
             # report success until the future was actually cancelled.
             already_cancelled = current_read.cancel()
             if already_cancelled:
-                return trio.hazmat.Abort.SUCCEEDED
+                return trio.lowlevel.Abort.SUCCEEDED
             else:
                 # Continue dealing with the cancellation once
                 # future.cancel() goes to the result of
                 # wait_task_rescheduled()
-                return trio.hazmat.Abort.FAILED
+                return trio.lowlevel.Abort.FAILED
 
     try:
         while True:
             # Schedule in asyncio that we read the next item from the iterator
             current_read = asyncio.ensure_future(consume_next(), loop=loop)
 
-            item = await trio.hazmat.wait_task_rescheduled(abort_cb)
+            item = await trio.lowlevel.wait_task_rescheduled(abort_cb)
 
             if item is STOP:
                 break

--- a/trio_asyncio/_util.py
+++ b/trio_asyncio/_util.py
@@ -6,7 +6,6 @@ import asyncio
 import sys
 import outcome
 import sniffio
-from async_generator import async_generator, yield_
 
 
 async def run_aio_future(future):
@@ -59,7 +58,6 @@ async def run_aio_future(future):
 STOP = object()
 
 
-@async_generator
 async def run_aio_generator(loop, async_generator):
     """Return a Trio-flavored async iterator which wraps the given
     asyncio-flavored async iterator (usually an async generator, but
@@ -116,7 +114,7 @@ async def run_aio_generator(loop, async_generator):
 
             if item is STOP:
                 break
-            await yield_(item)
+            yield item
 
     except asyncio.CancelledError as exc:
         if raise_cancel is not None:
@@ -130,7 +128,6 @@ async def run_aio_generator(loop, async_generator):
             raise
 
 
-@async_generator
 async def run_trio_generator(loop, async_generator):
     """Run a Trio generator from within asyncio"""
     while True:
@@ -140,7 +137,7 @@ async def run_trio_generator(loop, async_generator):
         except StopAsyncIteration:
             break
         else:
-            await yield_(item)
+            yield item
 
 
 # Copied from Trio:


### PR DESCRIPTION
I've added a few commits on top of #82:

 * pass the loop argument expicitly as required by @oremanj (and ignoring the resulting deprecation warning)
 * test Python 3.8 on macOS and Windows
 * fix tests on Python 3.10

I still have one error in a Windows + Python 3.8 test: https://ci.appveyor.com/project/pquentin/trio-asyncio/builds/33592085/job/gmo3loxfg3402xf6. Maybe we should leave Windows + Python 3.8 full testsuite support for another pull request?