### PR TITLE
Improve docs CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
           - python: '3.8'
             check_formatting: '1'
             extra_name: ', check formatting'
-          - python: '3.8'
-            check_docs: '1'
-            extra_name: ', check docs'
         # pypy3.7-nightly produces an "OSError: handle is closed" in the
         # bowels of multiprocessing after all tests appear to complete successfully
         #  - python: '3.7'  # <- not actually used

--- a/ci.sh
+++ b/ci.sh
@@ -103,14 +103,6 @@ EOF
         exit 1
     fi
     exit 0
-fi
-
-if [ "$CHECK_DOCS" = "1" ]; then
-    python -m pip install -r docs-requirements.txt
-    cd docs
-    # -n (nit-picky): warn on missing references
-    # -W: turn warnings into errors
-    sphinx-build -nW  -b html source build
 else
     # Actual tests
     python -m pip install -r test-requirements.txt

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,6 +1,7 @@
 sphinx >= 1.7.0
 sphinx_rtd_theme
 sphinxcontrib-trio
+towncrier
 trio >= 0.15.0
 outcome
 attrs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,18 @@ import sys
 # So autodoc can import our package
 sys.path.insert(0, os.path.abspath('../..'))
 
+# https://docs.readthedocs.io/en/stable/builds.html#build-environment
+if "READTHEDOCS" in os.environ:
+    import glob
+    if glob.glob("../../newsfragments/*.*.rst"):
+        print("-- Found newsfragments; running towncrier --", flush=True)
+        import subprocess
+        subprocess.run(
+            ["towncrier", "--yes", "--date", "not released yet"],
+            cwd="../..",
+            check=True,
+        )
+
 # Warn about all references to unknown targets
 nitpicky = True
 # Except for these ones, which we expect to point to unknown targets:


### PR DESCRIPTION
- Run towncrier before building docs, so that errors in newsfragments get noticed by CI
- We have readthedocs CI integration set up now, so can drop the extra docs build in github actions