### PR TITLE
Cancel and join asyncio tasks when exiting an open_loop() block

### DIFF
--- a/newsfragments/91.feature.rst
+++ b/newsfragments/91.feature.rst
@@ -1,0 +1,8 @@
+Exiting an ``async with trio_asyncio.open_loop():`` block now cancels
+any asyncio tasks that are still running in the background, like
+:func:`asyncio.run` does, so that they have a chance to clean up
+resources by running async context managers and ``finally``
+blocks. Previously such tasks would simply be abandoned to the garbage
+collector, resulting in potential deadlocks and stderr spew. Note that,
+like :func:`asyncio.run`, we *do* still abandon any tasks that are
+started during this finalization phase and outlive the existing tasks.

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -86,8 +86,7 @@ async def test_tasks_get_cancelled():
         tasks.append(asyncio.ensure_future(aio_sleeper("aio early")))
         loop.run_trio_task(trio_sleeper, "trio early")
 
-    assert record[0] == "aio early"
-    assert set(record[1:]) == {"trio early", "trio late"}
+    assert set(record) == {"aio early", "trio early", "trio late"}
     assert len(tasks) == 2 and tasks[0].done() and not tasks[1].done()
 
     # Suppress "Task was destroyed but it was pending!" message

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -1,6 +1,8 @@
 import pytest
 import sys
+import types
 import asyncio
+import trio
 from async_generator import async_generator, yield_
 import trio_asyncio
 
@@ -47,3 +49,54 @@ async def test_get_running_loop():
             pass  # Python 3.6
         else:
             assert get_running_loop() == loop
+
+
+@pytest.mark.trio
+async def test_tasks_get_cancelled():
+    record = []
+    tasks = []
+
+    @types.coroutine
+    def aio_yield():
+        yield
+
+    async def aio_sleeper(key):
+        try:
+            await asyncio.sleep(10)
+            record.append("expired")
+        finally:
+            try:
+                # Prove that we're still running in the aio loop, not
+                # some GC pass
+                await aio_yield()
+            finally:
+                record.append(key)
+                if "early" in key:
+                    tasks.append(asyncio.ensure_future(aio_sleeper("aio late")))
+                    asyncio.get_event_loop().run_trio_task(trio_sleeper, "trio late")
+
+    async def trio_sleeper(key):
+        try:
+            await trio.sleep_forever()
+        finally:
+            await trio.lowlevel.cancel_shielded_checkpoint()
+            record.append(key)
+
+    async with trio_asyncio.open_loop() as loop:
+        tasks.append(asyncio.ensure_future(aio_sleeper("aio early")))
+        loop.run_trio_task(trio_sleeper, "trio early")
+
+    assert record[0] == "aio early"
+    assert set(record[1:]) == {"trio early", "trio late"}
+    assert len(tasks) == 2 and tasks[0].done() and not tasks[1].done()
+
+    # Suppress "Task was destroyed but it was pending!" message
+    tasks[1]._log_traceback = False
+    tasks[1]._log_destroy_pending = False
+
+    # Suppress the "coroutine ignored GeneratorExit" message
+    while True:
+        try:
+            tasks[1]._coro.throw(SystemExit)
+        except SystemExit:
+            break

--- a/trio_asyncio/_loop.py
+++ b/trio_asyncio/_loop.py
@@ -13,6 +13,7 @@ except ImportError:
     from async_generator import asynccontextmanager
 
 from ._async import TrioEventLoop
+from ._util import run_aio_future
 from ._deprecate import warn_deprecated
 
 try:


### PR DESCRIPTION
This makes open_loop() work like asyncio.run(), giving "background" tasks a chance to unwind themselves, rather than simply abandoning them to the garbage collector.

Like asyncio.run(), we don't catch tasks that are spawned after delivering the cancellations -- those will get abandoned like before. This is maybe fixable in theory but it's probably more trouble than it's worth.

Fixes #91