### PR TITLE
Modernize sniffio integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['pypy-3.7', 'pypy-3.8', 'pypy-3.9', '3.7', '3.8', '3.9', '3.10', '3.11', '3.12-dev', 'pypy-3.8-nightly', 'pypy-3.9-nightly']
+        python: ['pypy-3.7', 'pypy-3.8', 'pypy-3.9', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy-3.8-nightly', 'pypy-3.9-nightly']
         check_formatting: ['0']
         extra_name: ['']
         include:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,8 +5,12 @@ formats:
   - htmlzip
   - epub
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.7
   install:
     - requirements: docs-requirements.txt
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -104,7 +104,7 @@ release = version
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/newsfragments/123.misc.rst
+++ b/newsfragments/123.misc.rst
@@ -1,0 +1,5 @@
+trio-asyncio now indicates its presence to `sniffio` using the
+``sniffio.thread_local`` interface that is preferred since sniffio
+v1.3.0. This should be less likely than the previous approach to cause
+:func:`sniffio.current_async_library` to return incorrect results due
+to unintended inheritance of contextvars.

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     install_requires=[
         "trio >= 0.22.0",
         "outcome",
-        "sniffio",
+        "sniffio >= 1.3.0",
         "exceptiongroup >= 1.0.0; python_version < '3.11'",
     ],
     # This means, just install *everything* you see under trio/, even if it

--- a/trio_asyncio/_handles.py
+++ b/trio_asyncio/_handles.py
@@ -2,7 +2,6 @@ import sys
 import trio
 import types
 import asyncio
-import sniffio
 from asyncio.format_helpers import _format_callback, _get_function_source
 
 if sys.version_info < (3, 11):
@@ -139,7 +138,6 @@ class AsyncHandle(ScopedHandle):
                     self.cancel()
 
     async def _run(self):
-        sniffio.current_async_library_cvar.set("trio")
         self._started.set()
         if self._cancelled:
             return

--- a/trio_asyncio/_util.py
+++ b/trio_asyncio/_util.py
@@ -5,7 +5,6 @@ import trio
 import asyncio
 import sys
 import outcome
-import sniffio
 
 
 async def run_aio_future(future):
@@ -69,7 +68,6 @@ async def run_aio_generator(loop, async_generator):
     current_read = None
 
     async def consume_next():
-        t = sniffio.current_async_library_cvar.set("asyncio")
         try:
             item = await async_generator.__anext__()
             result = outcome.Value(value=item)
@@ -80,8 +78,6 @@ async def run_aio_generator(loop, async_generator):
             return
         except Exception as e:
             result = outcome.Error(error=e)
-        finally:
-            sniffio.current_async_library_cvar.reset(t)
 
         trio.lowlevel.reschedule(task, result)
 


### PR DESCRIPTION
Use `sniffio.thread_local` to indicate which async library is running, instead of the deprecated `sniffio.current_async_library_cvar`. This allows us to remove a number of workarounds for the contextvar being inherited where it shouldn't be, and is also necessary to interoperate with Trio 0.23 which uses the thread-local.

Fixes #123.