### PR TITLE
Fix potential deadlock if open_loop() is cancelled

### DIFF
--- a/newsfragments/115.bugfix.rst
+++ b/newsfragments/115.bugfix.rst
@@ -1,0 +1,4 @@
+A deadlock will no longer occur if :func:`trio_asyncio.open_loop`
+is cancelled before its first checkpoint. We also now cancel and wait on
+all asyncio tasks even if :func:`~trio_asyncio.open_loop` terminates due
+to an exception that was raised within the ``async with`` block.


### PR DESCRIPTION
Resolves #115. This also modifies the "cancel and await all asyncio tasks" logic to run even if `open_loop()` is cancelled or sees an exception, because that's another potential source of deadlocks -- the Trio tasks in the `tasks_nursery` might need to block on asyncio work as they unwind.