### PR TITLE
Use an infinite queue_len by default, and advise against reducing it

### DIFF
--- a/newsfragments/130.bugfix.rst
+++ b/newsfragments/130.bugfix.rst
@@ -1,0 +1,7 @@
+trio-asyncio no longer applies a limit to the maximum number of
+asyncio callbacks (including new task creations) that can be enqueued
+near-simultaneously. Previously the default limit was 10,000. A limit
+may still be requested using the *queue_len* parameter to
+:func:`open_loop`, but this is discouraged because there is no way
+to fail gracefully upon exceeding the limit; it will most likely just
+crash your program.

--- a/trio_asyncio/_base.py
+++ b/trio_asyncio/_base.py
@@ -141,7 +141,7 @@ class BaseTrioEventLoop(asyncio.SelectorEventLoop):
 
     def __init__(self, queue_len=None):
         if queue_len is None:
-            queue_len = 10000
+            queue_len = math.inf
 
         # Processing queue
         self._q_send, self._q_recv = trio.open_memory_channel(queue_len)


### PR DESCRIPTION
Fixes #130. It is unreasonably difficult to fail gracefully upon exceeding this limit, and stock asyncio has no similar limit, so be unlimited by default and encourage users not to change that. We still leave the `queue_len` option in case someone has a good use for it.