### PR TITLE
_base.py: fix double acquire by TrioExecuto, issue #143

### DIFF
--- a/newsfragments/143.bugfix.rst
+++ b/newsfragments/143.bugfix.rst
@@ -1,0 +1,3 @@
+``TrioExecutor.submit``, called from :meth:`asyncio.loop.run_in_executor`, no longer acquires a token from its `~trio.CapacityLimiter` before calling `~trio.to_thread.run_sync` (which already does its own ``acquire()``).
+
+The previous behaviour led to a double-acquire, leading each worker thread to require two tokens to run instead of one. Tasks could get stuck having acquired the first token but unable to acquire the second as part of `~trio.to_thread.run_sync`, leading to a deadlock.

--- a/trio_asyncio/_base.py
+++ b/trio_asyncio/_base.py
@@ -84,14 +84,8 @@ class TrioExecutor(concurrent.futures.ThreadPoolExecutor):
     async def submit(self, func, *args):
         if not self._running:  # pragma: no cover
             raise RuntimeError("Executor is down")
-        lim = self._limiter
-        if lim is not None:
-            await lim.acquire()
-        try:
-            return await trio.to_thread.run_sync(func, *args, limiter=self._limiter)
-        finally:
-            if lim is not None:
-                lim.release()
+        # there is no need to call self._limiter.acquire() here, run_sync does it
+        return await trio.to_thread.run_sync(func, *args, limiter=self._limiter)
 
     def shutdown(self, wait=None):
         self._running = False


### PR DESCRIPTION
Fixes  #143 

Ran `pytest` on both `master` and the branch with the fix - output is the same (there are existing failures):

- on `executor-double-acquire-fix`
```
=============================================== short test summary info ================================================
FAILED tests/interop/test_calls.py::TestCalls::test_trio_asyncio_cancel_direct - BaseExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_misc.py::test_keyboard_interrupt_teardown - BaseExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_misc.py::test_cancel_loop[True] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_misc.py::test_run_trio_task_errors - BaseExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_trio_asyncio.py::test_cancel_loop_with_tasks[True-False] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_trio_asyncio.py::test_cancel_loop_with_tasks[True-True] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
=========================== 6 failed, 2504 passed, 62 skipped, 4 xfailed in 71.12s (0:01:11) ===========================
```

-  on `master`
```
================================================ short test summary info ================================================
FAILED tests/interop/test_calls.py::TestCalls::test_trio_asyncio_cancel_direct - BaseExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_misc.py::test_keyboard_interrupt_teardown - BaseExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_misc.py::test_cancel_loop[True] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_misc.py::test_run_trio_task_errors - BaseExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_trio_asyncio.py::test_cancel_loop_with_tasks[True-False] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
FAILED tests/test_trio_asyncio.py::test_cancel_loop_with_tasks[True-True] - ExceptionGroup: Exceptions from Trio nursery (1 sub-exception)
=========================== 6 failed, 2504 passed, 62 skipped, 4 xfailed in 71.33s (0:01:11) ============================
```