### PR TITLE
pin trio to <0.25.0 due to breaking changes

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@ sphinx >= 1.7.0
 sphinx_rtd_theme
 sphinxcontrib-trio
 towncrier
-trio >= 0.15.0
+trio >= 0.15.0,< 0.25.0
 outcome
 attrs
 greenlet

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-trio
 outcome
 pytest-timeout
+trio >= 0.15.0,< 0.25.0


### PR DESCRIPTION
0.25.0 causes some tests to fail - c.f. [release notes](https://github.com/python-trio/trio/releases)