### PR TITLE
[tests] support trio's new exception groups, bump min trio rev to 0.25.0

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -2,7 +2,7 @@ sphinx >= 1.7.0
 sphinx_rtd_theme
 sphinxcontrib-trio
 towncrier
-trio >= 0.15.0,< 0.25.0
+trio >= 0.25.0
 outcome
 attrs
 greenlet

--- a/newsfragments/146.misc.rst
+++ b/newsfragments/146.misc.rst
@@ -1,0 +1,1 @@
+Updated test suite to cope with Trio 0.25.0 and later defaulting ``strict_exception_groups`` to ``True``. Trio 0.25.0 is now required to run the tests, although trio-asyncio itself still supports older versions.

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ pytest-cov
 pytest-trio
 outcome
 pytest-timeout
-trio >= 0.15.0,< 0.25.0
+trio >= 0.25.0

--- a/tests/interop/test_calls.py
+++ b/tests/interop/test_calls.py
@@ -299,7 +299,7 @@ class TestCalls(aiotest.TestCase):
                 seen.flag |= 8
 
         seen = Seen()
-        with pytest.raises(asyncio.CancelledError):
+        with trio.testing.RaisesGroup(asyncio.CancelledError):
             await cancel_trio(seen)
         assert seen.flag == 1 | 8
 

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -121,7 +121,9 @@ async def test_cancel_loop_with_tasks(autojump_clock, shield, body_raises):
     record = []
 
     if body_raises:
-        catcher = pytest.raises(ValueError, match="hi")
+        catcher = trio.testing.RaisesGroup(
+            trio.testing.Matcher(ValueError, match="hi"), strict=False
+        )
     else:
         catcher = contextlib.nullcontext()
 


### PR DESCRIPTION
Fixes #146.

Technically it's only the tests that are impacted but for completeness I also bumped the `trio` version on `docs-requirements.txt`.