### PR TITLE
Fix spurious error when asyncio.run() task raises SystemExit

### DIFF
--- a/newsfragments/149.bugfix.rst
+++ b/newsfragments/149.bugfix.rst
@@ -1,0 +1,3 @@
+trio-asyncio no longer raises a spurious "Event loop stopped before Future
+completed!" exception if a function passed to :func:`asyncio.run` calls
+:func:`sys.exit`.

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -193,3 +193,13 @@ async def test_executor_limiter_deadlock():
             await trio_asyncio.aio_as_trio(loop.run_in_executor)(executor, noop)
 
     assert not scope.cancelled_caught
+
+
+def test_system_exit():
+    async def main():
+        raise SystemExit(42)
+
+    with pytest.raises(SystemExit) as scope:
+        asyncio.run(main())
+
+    assert scope.value.code == 42

--- a/trio_asyncio/_sync.py
+++ b/trio_asyncio/_sync.py
@@ -139,6 +139,14 @@ class SyncTrioEventLoop(BaseTrioEventLoop):
             nonlocal result
 
             result = outcome.capture(future.result)
+            if isinstance(result, outcome.Error) and isinstance(
+                result.error, (SystemExit, KeyboardInterrupt)
+            ):
+                # These exceptions propagate out of the event loop;
+                # don't stop the event loop again, or else it will
+                # interfere with cleanup actions like
+                # run_until_complete(shutdown_asyncgens)
+                return
             self.stop()
 
         future.add_done_callback(is_done)


### PR DESCRIPTION
SystemExit passes through the asyncio loop, so the `stop()` callback scheduled by the main task's Future's completion doesn't run; which then means it's pending when we re-enter the asyncio loop to do cleanup tasks like `shutdown_asyncgens`. Fix by not enqueueing the `stop()` callback if we can tell that the exception is going to pass through the asyncio loop.

Relevant upstream issue: https://bugs.python.org/issue22429