### PR TITLE
Finalize async generators in the correct context

### DIFF
--- a/newsfragments/92.feature.rst
+++ b/newsfragments/92.feature.rst
@@ -1,0 +1,4 @@
+trio-asyncio now properly finalizes asyncio-flavored async generators
+upon closure of the event loop. Previously, Trio's async generator finalizers
+would try to finalize all async generators in Trio mode, regardless of their
+flavor, which could lead to spurious errors.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,7 @@ import unittest
 @pytest.fixture
 async def loop():
     async with trio_asyncio.open_loop() as loop:
-        try:
-            yield loop
-        finally:
-            await loop.stop().wait()
+        yield loop
 
 
 # auto-trio-ize all async functions


### PR DESCRIPTION
Install custom async generator hooks that finalize each asyncgen in the same context (trio vs asyncio mode, and the correct trio-asyncio loop if asyncio mode) as it was first iterated. Fixes #92.