### PR TITLE
fix RaisesGroup(strict=...) in tests, removed in trio 0.27

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,4 +15,5 @@ python:
     - requirements: docs-requirements.txt
 
 sphinx:
+  configuration: docs/source/conf.py
   fail_on_warning: true

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -132,7 +132,6 @@ todo_include_todos = False
 # html_theme_options.
 import sphinx_rtd_theme
 html_theme = 'sphinx_rtd_theme'
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ pytest-cov
 pytest-trio
 outcome
 pytest-timeout
-trio >= 0.25.0
+trio >= 0.26.0

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -333,9 +333,9 @@ async def test_run_trio_task_errors(monkeypatch):
     )
     expected = [ValueError("hi"), ValueError("lo"), KeyError(), IndexError()]
     await raise_in_aio_loop(expected[0])
-    with trio.testing.RaisesGroup(SystemExit, strict=False):
+    with trio.testing.RaisesGroup(SystemExit, flatten_subgroups=True):
         await raise_in_aio_loop(SystemExit(0))
-    with trio.testing.RaisesGroup(SystemExit, strict=False) as result:
+    with trio.testing.RaisesGroup(SystemExit, flatten_subgroups=True) as result:
         await raise_in_aio_loop(BaseExceptionGroup("", [expected[1], SystemExit()]))
 
     assert len(result.value.exceptions) == 1

--- a/tests/test_trio_asyncio.py
+++ b/tests/test_trio_asyncio.py
@@ -124,7 +124,7 @@ async def test_cancel_loop_with_tasks(autojump_clock, shield, body_raises):
 
     if body_raises:
         catcher = trio.testing.RaisesGroup(
-            trio.testing.Matcher(ValueError, match="hi"), strict=False
+            trio.testing.Matcher(ValueError, match="hi"), flatten_subgroups=True
         )
     else:
         catcher = contextlib.nullcontext()


### PR DESCRIPTION
Trivial fix replacing `RaisesGroup(strict=False)` with `RaisesGroup(flatten_subgroups=True)` in tests (`strict` was deprecated in Trio 0.26 and removed in Trio 0.27 in October 2024).

Also fixes a couple of tiny docs-related issues that were breaking the docs build due to recent external changes, and thus failing CI:
1. RTD [now requires](https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/) an explicit `configuration` setting specifying the config file.
2. Sphinx no longer requires an explicit call to `get_html_theme_path()`, and in fact warns `WARNING: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.` (and CI treats warns as errors).

Fixes #154