### PR TITLE
Update supported Python versions - add 3.13, remove 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
         arch: ['x86', 'x64']
     steps:
       - name: Checkout
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['pypy-3.9', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9-nightly']
+        python: ['pypy-3.9', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.9-nightly']
         check_formatting: ['0']
         extra_name: ['']
         include:
@@ -98,7 +98,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy-3.9-nightly']
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.9-nightly']
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ formats:
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "3.13"
 
 python:
   install:

--- a/README.rst
+++ b/README.rst
@@ -26,8 +26,8 @@
 **trio-asyncio** is a re-implementation of the ``asyncio`` mainloop on top of
 Trio.
 
-trio-asyncio requires at least Python 3.8. It is tested on recent versions of
-3.8 through 3.12.
+trio-asyncio requires at least Python 3.9. It is tested on recent versions of
+3.9 through 3.13.
 
 +++++++++++
  Rationale

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: dh-python, python3-setuptools, python3-all, debhelper (>= 9),
   python3-pytest-runner,
   python3-outcome,
 Standards-Version: 3.9.6
-Homepage: https://github.com/smurfix/trio-asyncio
+Homepage: https://github.com/python-trio/trio-asyncio
 
 Package: python3-trio-asyncio
 Architecture: all

--- a/newsfragments/###.misc.rst
+++ b/newsfragments/###.misc.rst
@@ -1,0 +1,1 @@
+Python 3.13 is now supported. Python 3.8 is no longer supported.

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ This works rather well: ``trio_asyncio`` consists of just ~700 lines of
 code (asyncio: ~8000) but passes the complete Python 3.6 test suite with no
 errors.
 
-``trio_asyncio`` requires Python 3.8 or later.
+``trio_asyncio`` requires Python 3.9 or later.
 
 Author
 ======
@@ -72,7 +72,7 @@ setup(
     # This means, just install *everything* you see under trio/, even if it
     # doesn't look like a source file, so long as it appears in MANIFEST.in:
     include_package_data=True,
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     keywords=["async", "io", "trio", "asyncio", "trio-asyncio"],
     setup_requires=["pytest-runner"],
     tests_require=["pytest >= 5.4", "pytest-trio >= 0.6", "outcome"],
@@ -88,11 +88,11 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: System :: Networking",
         "Framework :: Trio",
         "Framework :: AsyncIO",


### PR DESCRIPTION
Update supported Python versions to follow Trio itself (and of course, 3.8 is EOL).